### PR TITLE
Add support for glob pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,10 +121,15 @@ Inspired by [ripgrep](https://github.com/BurntSushi/ripgrep), you can also selec
 $ ruplacer old new --type cpp
 # Select only *.foo files
 $ ruplacer old new --type *.foo
+# Select only files that match foo*bar.c
+$ ruplacer old new --type foo*bar.c
+
 # Ignore all js files
 $ ruplacer old new --type-not js
 # Ignore all *.bar files
 $ ruplacer old new --type-not *.bar
+# Ignore all files that match foo*bar.c
+$ ruplacer old new --type-not foo*bar.c
 ```
 
 Each "file type" is just a list of glob pattern. For instance: the `cpp` file type matches `*.C`, `*.H`, `*.cc`, `*.cpp` and so on ...

--- a/README.md
+++ b/README.md
@@ -112,15 +112,19 @@ Patching src/foo.txt
 ++ spam_eggs, SpamEggs, and SPAM_EGGS!
 ```
 
-## Filter files by type
+## Filter files by type or glob patterns
 
-Inspired by [ripgrep](https://github.com/BurntSushi/ripgrep), you can also select or ignore certain "file types":
+Inspired by [ripgrep](https://github.com/BurntSushi/ripgrep), you can also select or ignore certain "file types" or glob patterns:
 
 ```
 # Select only C++ files
 $ ruplacer old new --type cpp
+# Select only *.foo files
+$ ruplacer old new --type *.foo
 # Ignore all js files
-$ ruplacer old new --type-ignore js
+$ ruplacer old new --type-not js
+# Ignore all *.bar files
+$ ruplacer old new --type-not *.bar
 ```
 
 Each "file type" is just a list of glob pattern. For instance: the `cpp` file type matches `*.C`, `*.H`, `*.cc`, `*.cpp` and so on ...

--- a/src/directory_patcher.rs
+++ b/src/directory_patcher.rs
@@ -62,8 +62,10 @@ impl DirectoryPatcher {
         types_builder.add_defaults();
         let mut cnt: u32 = 0;
         for t in &self.settings.selected_file_types {
+            // Check if filter is file type or glob pattern
             if t.contains("*") {
                 let new_type = format!("type{}", cnt);
+                // Note: .add(name, glob) only returns error with wrong name, hence unwrap()
                 types_builder.add(&new_type, t).unwrap();
                 types_builder.select(&new_type);
                 cnt += 1;
@@ -72,8 +74,10 @@ impl DirectoryPatcher {
             }
         }
         for t in &self.settings.ignored_file_types {
+            // Check if filter is file type or glob pattern
             if t.contains("*") {
                 let new_type = format!("type{}", cnt);
+                // Note: .add(name, glob) only returns error with wrong name, hence unwrap()
                 types_builder.add(&new_type, t).unwrap();
                 types_builder.negate(&new_type);
                 cnt += 1;

--- a/src/directory_patcher.rs
+++ b/src/directory_patcher.rs
@@ -60,11 +60,26 @@ impl DirectoryPatcher {
     fn build_walker(&self) -> ignore::Walk {
         let mut types_builder = ignore::types::TypesBuilder::new();
         types_builder.add_defaults();
+        let mut cnt: u32 = 0;
         for t in &self.settings.selected_file_types {
-            types_builder.select(t);
+            if t.contains("*") {
+                let new_type = format!("type{}", cnt);
+                types_builder.add(&new_type, t).unwrap();
+                types_builder.select(&new_type);
+                cnt += 1;
+            } else {
+                types_builder.select(t);
+            }
         }
         for t in &self.settings.ignored_file_types {
-            types_builder.negate(t);
+            if t.contains("*") {
+                let new_type = format!("type{}", cnt);
+                types_builder.add(&new_type, t).unwrap();
+                types_builder.negate(&new_type);
+                cnt += 1;
+            } else {
+                types_builder.negate(t);
+            }
         }
         let types_matcher = types_builder
             .build()

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,7 @@ struct Options {
     #[structopt(
         short = "t",
         long = "type",
-        help = "Only search files matching <file_type>",
+        help = "Only search files matching <file_type> or glob pattern.",
         multiple = true,
         number_of_values = 1
     )]
@@ -94,7 +94,7 @@ struct Options {
     #[structopt(
         short = "T",
         long = "type-not",
-        help = "Ignore files matching <file_type>",
+        help = "Ignore files matching <file_type> or glob pattern.",
         multiple = true,
         number_of_values = 1
     )]


### PR DESCRIPTION
Workaround for https://github.com/dmerejkowsky/ruplacer/issues/56. Instead of regex, I think glob pattern would be more suited because the `ignore` crate already supported it.