### PR TITLE
Add `-V`, `--version` option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ impl std::str::FromStr for ColorWhen {
 #[derive(Debug, Parser)]
 #[clap(
     name = "ruplacer",
+    version,
     after_help = "
 EXAMPLES:
     Replace 'foo' with 'bar'


### PR DESCRIPTION
I find it very helpful to have a tool tell me it's version so I can consider upgrading to a newer version or track down bugs.

This change adds the common `--version` option/switch (along with `-V`). Fortunately, Clap makes this _very easy_ by using a magic command attribute: https://github.com/clap-rs/clap/blob/v3.1.15/examples/derive_ref/README.md#command-attributes

Output of `ruplacer --version`:
```
ruplacer 0.6.4
```

Additional output of `ruplacer --help`:
```
ruplacer 0.6.4

[…]

    -V, --version
            Print version information

[…]
```