### PR TITLE
Add multi-threading support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,11 +240,20 @@ checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+checksum = "029d8d0b2f198229de29dca79676f2738ff952edf3fde542eb8bf94d8c21b435"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "patricia_tree"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c4b8ef84caee22395fa083b7d8ee9351e71cdf69a46c832528acdcac402117"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -380,6 +389,8 @@ dependencies = [
  "clap",
  "colored",
  "ignore",
+ "os_str_bytes",
+ "patricia_tree",
  "regex",
  "tempfile",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e50f3adc76d6a43f5ed73b698a87d0760ca74617f60f7c3b879003536fdd28"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,6 +394,7 @@ dependencies = [
  "atty",
  "clap",
  "colored",
+ "dyn-clone",
  "ignore",
  "os_str_bytes",
  "patricia_tree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ anyhow = "1.0.32"
 atty = "0.2.14"
 clap = { version = "3.0.7", features = ["derive"] }
 colored = "2.0"
+dyn-clone = "1.0.5"
 ignore = "0.4"
 Inflector = "0.11"
 os_str_bytes = "6.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ clap = { version = "3.0.7", features = ["derive"] }
 colored = "2.0"
 ignore = "0.4"
 Inflector = "0.11"
+os_str_bytes = "6.0.1"
+patricia_tree = "0.3.1"
 regex = "1.5.1"
 
 

--- a/src/directory_patcher.rs
+++ b/src/directory_patcher.rs
@@ -86,19 +86,25 @@ impl<'a> DirectoryPatcher<'a> {
         self.stats
     }
 
-    pub(crate) fn patch_file(&mut self, entry: &Path, query: &Query) -> Result<()> {
-        let file_patcher = FilePatcher::new(self.console, entry, query)?;
+    pub(crate) fn patch_file(
+        console: &Console,
+        stats: &Stats,
+        settings: &Settings,
+        entry: &Path,
+        query: &Query,
+    ) -> Result<()> {
+        let file_patcher = FilePatcher::new(console, entry, query)?;
         let file_patcher = match file_patcher {
             None => return Ok(()),
             Some(f) => f,
         };
         let num_replacements = file_patcher.num_replacements();
         if num_replacements != 0 {
-            self.console.print_message("\n");
+            console.print_message("\n");
         }
         let num_lines = file_patcher.num_lines();
-        self.stats.update(num_lines, num_replacements);
-        if self.settings.dry_run {
+        stats.update(num_lines, num_replacements);
+        if settings.dry_run {
             return Ok(());
         }
         file_patcher.run()?;

--- a/src/directory_patcher/path_deduplicator.rs
+++ b/src/directory_patcher/path_deduplicator.rs
@@ -1,0 +1,22 @@
+use std::path::Path;
+
+use os_str_bytes::RawOsStr;
+use patricia_tree::PatriciaSet;
+
+#[derive(Debug, Default)]
+pub struct PathDeduplicator {
+    set: PatriciaSet,
+}
+
+impl PathDeduplicator {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    // Returns `true` if the given `path` was called for this instance before.
+    pub fn insert_path(&mut self, path: &Path) -> bool {
+        let Self { set } = self;
+        let raw = RawOsStr::new(path.as_os_str());
+        set.insert(raw.as_raw_bytes())
+    }
+}

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,36 +1,40 @@
+use std::sync::atomic::{self, AtomicUsize};
+
 use inflector::string::pluralize::to_plural;
 
 #[derive(Default, Debug)]
 /// Statistics about a run of DirectoryPatcher
 pub struct Stats {
-    matching_files: usize,
-    matching_lines: usize,
-    total_replacements: usize,
+    matching_files: AtomicUsize,
+    matching_lines: AtomicUsize,
+    total_replacements: AtomicUsize,
 }
 
 impl Stats {
-    pub(crate) fn update(&mut self, lines: usize, replacements: usize) {
+    pub(crate) fn update(&self, lines: usize, replacements: usize) {
         if replacements == 0 {
             return;
         }
-        self.matching_files += 1;
-        self.matching_lines += lines;
-        self.total_replacements += replacements;
+        self.matching_files.fetch_add(1, atomic::Ordering::SeqCst);
+        self.matching_lines
+            .fetch_add(lines, atomic::Ordering::SeqCst);
+        self.total_replacements
+            .fetch_add(replacements, atomic::Ordering::SeqCst);
     }
 
     /// Number of matching files
     pub fn matching_files(&self) -> usize {
-        self.matching_files
+        self.matching_files.load(atomic::Ordering::SeqCst)
     }
 
     /// Total number of lines that were replaced
     pub fn matching_lines(&self) -> usize {
-        self.matching_lines
+        self.matching_lines.load(atomic::Ordering::SeqCst)
     }
 
     /// Total number of lines that were replaced
     pub fn total_replacements(&self) -> usize {
-        self.total_replacements
+        self.total_replacements.load(atomic::Ordering::SeqCst)
     }
 }
 
@@ -44,12 +48,15 @@ fn pluralize(input: &str, num: usize) -> String {
 
 impl std::fmt::Display for Stats {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        let file_string = pluralize("file", self.matching_files);
-        let replacements_string = pluralize("replacement", self.total_replacements);
+        let file_string = pluralize("file", self.matching_files());
+        let replacements_string = pluralize("replacement", self.total_replacements());
         write!(
             f,
             "{} {} on {} matching {}",
-            self.total_replacements, replacements_string, self.matching_files, file_string
+            self.total_replacements(),
+            replacements_string,
+            self.matching_files(),
+            file_string
         )
     }
 }
@@ -61,17 +68,17 @@ mod tests {
     #[test]
     fn test_stats_to_string() {
         let stats = Stats {
-            matching_files: 2,
-            total_replacements: 4,
-            matching_lines: 1,
+            matching_files: AtomicUsize::new(2),
+            total_replacements: AtomicUsize::new(4),
+            matching_lines: AtomicUsize::new(1),
         };
         let actual = stats.to_string();
         assert_eq!(actual, "4 replacements on 2 matching files");
 
         let stats = Stats {
-            matching_files: 1,
-            total_replacements: 2,
-            matching_lines: 1,
+            matching_files: AtomicUsize::new(1),
+            total_replacements: AtomicUsize::new(2),
+            matching_lines: AtomicUsize::new(1),
         };
         let actual = stats.to_string();
         assert_eq!(actual, "2 replacements on 1 matching file");


### PR DESCRIPTION
This (currently WIP) PR proposes switching to `ignore`'s parallel walker API. It's not complete yet (`threads` are still only set to 1), but I figured that I should start discussion with y'all here upstream before I got too carried away, since there's actually quite a few design considerations here, and I haven't even validated that this is something y'all want in the first place! :)

See individual commits for more details on changes. Note that this is based on #93, and commits specifically for _this_ PR start with the commit titled ``refactor: make `Stats` multithread-friendly``.